### PR TITLE
Changes to estimate_profiles_mplus2:

### DIFF
--- a/R/estimate-profiles.R
+++ b/R/estimate-profiles.R
@@ -90,6 +90,8 @@ estimate_profiles <- function(df,
     if(!inherits(package, "character")) stop("Argument package must be a character string.")
     if(!package %in% c("mclust", "MplusAutomation")) stop("Argument package must be one of 'mclust' or 'MplusAutomation'.")
 
+    if(inherits(df, "matrix")) df <- data.frame(df)
+
     # Screen df ---------------------------------------------------------------
 
     var_types <- sapply(df, class)

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -26,3 +26,10 @@
 #' iris %>%
 #'   subset(select = c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"))
 NULL
+
+
+quiet <- function(x) {
+    sink(tempfile())
+    on.exit(sink())
+    invisible(force(x))
+}

--- a/tests/testthat/test-pipe.R
+++ b/tests/testthat/test-pipe.R
@@ -1,0 +1,7 @@
+context("test-pipe.R")
+
+test_that("pipe is loaded and works", {
+  expect_equal({
+      c(1,2,3,4,5) %>%
+          mean()}, 3)
+})

--- a/tests/testthat/test-plot-profiles-mplus.R
+++ b/tests/testthat/test-plot-profiles-mplus.R
@@ -6,4 +6,16 @@ if(MplusAutomation::mplusAvailable() == 0){
         expect_s3_class(plot_profiles(out_mplus), "ggplot")
     })
 
+
+    test_that("matrix data are correctly read", {
+        df <- as.matrix(iris[, 1:4])
+        expect_error(estimate_profiles(df, n_profiles = 3, package = "MplusAutomation"), NA)
+    })
+
+    test_that("Parsing variable names throws error if variable names are not unique", {
+        df <- iris[, 1:4]
+        names(df)[1:2] <- c("Sepal.Length1", "Sepal.Length2")
+        expect_error(estimate_profiles(df, n_profiles = 3, package = "MplusAutomation"))
+    })
+
 }


### PR DESCRIPTION
* Now handles matrix data.
* No longer printing MplusAutomation messages
* Now gives an error when variables cannot be renamed, instead of warnings when they can be
* Added tests for these new functionalities